### PR TITLE
fix issue with nan values in force data messing up automatic assigment

### DIFF
--- a/pyCGM2/ForcePlates/forceplates.py
+++ b/pyCGM2/ForcePlates/forceplates.py
@@ -126,7 +126,7 @@ def matchingFootSideOnForceplate (btkAcq, enableRefine=True, forceThreshold=50, 
             ax.plot(diffL,'-r')
             ax.plot(diffR,'-b')
 
-        if np.min(diffL)<np.min(diffR):
+        if np.nanmin(diffL)<np.nanmin(diffR):
             logging.debug(" Force plate " + str(i) + " : left foot")
             suffix = suffix +  "L"
         else:


### PR DESCRIPTION
After testing out the changes with Ground Reaction Force data I noticed that for some files one of the (L/R) data was all zeroes.

The underlying cause was that there was some NaNs in that particular force data, so the np.min comparisons always compared NaNs to each other.

Changed the np.min to np.nanmin that ignores nan values in the minimum calculation. 