### PR TITLE
change path fetching in init to work with pyInstaller executable

### DIFF
--- a/pyCGM2/Processing/cycle.py
+++ b/pyCGM2/Processing/cycle.py
@@ -347,16 +347,19 @@ class GaitCycle(Cycle):
             - Each GaitCycle creation computes spatio-temporal parameters automatically.
             - spatio-temporal parameters are :
                 "duration", "cadence",
-                "stanceDuration", "stancePhase",
+                "stanceDuration", "stepDuration", "doubleStance1Duration",
+                "doubleStance2Duration", "simpleStanceDuration", "stancePhase",
                 "swingDuration", "swingPhase", "doubleStance1", "doubleStance2",
-                "simpleStance", "strideLength", "stepLength",
+                "simpleStance", "stepPhase", "strideLength", "stepLength",
                 "strideWidth", "speed"
     """
 
 
-    STP_LABELS=["duration","cadence", "stanceDuration",  "stancePhase",
+    STP_LABELS=["duration","cadence",
+                "stanceDuration", "stepDuration", "doubleStance1Duration",
+                "doubleStance2Duration","simpleStanceDuration","stancePhase",
                 "swingDuration", "swingPhase", "doubleStance1", "doubleStance2",
-                "simpleStance", "strideLength", "stepLength",
+                "simpleStance", "stepPhase","strideLength", "stepLength",
                 "strideWidth", "speed"]
 
 

--- a/pyCGM2/Report/plotViewers.py
+++ b/pyCGM2/Report/plotViewers.py
@@ -108,7 +108,7 @@ class SpatioTemporalPlotViewer(AbstractPlotViewer):
                                 title="Step length", xlabel=None,xlim=None)
 
         plot.stpHorizontalHistogram(self.fig.axes[5],self.m_analysis.stpStats,
-                                "duration",
+                                "stepDuration",
                                 overall= False,
                                 title="Step time", xlabel=None,xlim=None)
 

--- a/pyCGM2/__init__.py
+++ b/pyCGM2/__init__.py
@@ -29,8 +29,7 @@ except Exception, errormsg:
 ENCODER = "latin-1"
 
 # CONSTANTS
-cased_path = glob.glob(re.sub(r'([^:])(?=[/\\]|$)', r'[\1]', __file__))[0]
-MAIN_PYCGM2_PATH = os.path.abspath(os.path.join(os.path.dirname(cased_path), os.pardir)) + "\\"
+MAIN_PYCGM2_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)) + "\\"
 
 #  [Optional] setting folder
 PYCGM2_SETTINGS_FOLDER = MAIN_PYCGM2_PATH+"pyCGM2\Settings\\"


### PR DESCRIPTION
This line was problematic when running CGM1_workflow after packaging an executable with pyInstaller.

The change fixes that issue. Sadly I could not run the unit tests myself, since I don't have access to the test files. 