### PR TITLE
fix missing SpatioTemporal page in pdf report and add missing units

### DIFF
--- a/pyCGM2/Lib/report.py
+++ b/pyCGM2/Lib/report.py
@@ -22,6 +22,7 @@ def pdfGaitReport(DATA_PATH,model,modelledTrials, normativeDataset,pointSuffix, 
             outputName=title,
             show=None,
             title=title)
+        pdf.savefig()
 
         #Kinematics
         if model.m_bodypart in [enums.BodyPart.LowerLimb,enums.BodyPart.LowerLimbTrunk, enums.BodyPart.FullBody]:

--- a/pyCGM2/Report/plotViewers.py
+++ b/pyCGM2/Report/plotViewers.py
@@ -104,17 +104,17 @@ class SpatioTemporalPlotViewer(AbstractPlotViewer):
         plot.stpHorizontalHistogram(self.fig.axes[3],self.m_analysis.stpStats,
                                 "cadence",
                                 overall= True,
-                                title="cadence", xlabel=None,xlim=None)
+                                title="cadence (strides/min)", xlabel=None,xlim=None)
 
         plot.stpHorizontalHistogram(self.fig.axes[4],self.m_analysis.stpStats,
                                 "stepLength",
                                 overall= False,
-                                title="Step length", xlabel=None,xlim=None)
+                                title="Step length (m)", xlabel=None,xlim=None)
 
         plot.stpHorizontalHistogram(self.fig.axes[5],self.m_analysis.stpStats,
                                 "stepDuration",
                                 overall= False,
-                                title="Step time", xlabel=None,xlim=None)
+                                title="Step time (s)", xlabel=None,xlim=None)
 
         plot.stpHorizontalHistogram(self.fig.axes[6],self.m_analysis.stpStats,
                                 "stancePhase",


### PR DESCRIPTION
In the process of filling Nils request to add missing units from SpatioTemporal parameter titles in pdf report I also discovered that the page did not even show up in the saved pdf. So I changed that as well