### PR TITLE
add an argument that controls if Mokka opens or not

### DIFF
--- a/pyCGM2/Apps/QtmApps/CGMi/CGM11_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM11_workflow.py
@@ -38,7 +38,7 @@ def command():
     sessionFilename = args.sessionFile
     main(sessionFilename)
 
-def main(sessionFilename,createPDFReport=True):
+def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
     logging.info("------------------------------------------------")
     logging.info("------------QTM - pyCGM2 Workflow---------------")
     logging.info("------------------------------------------------")
@@ -76,7 +76,7 @@ def main(sessionFilename,createPDFReport=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState:
+            if zeniState and checkEventsInMokka:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
 
                 cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM11_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM11_workflow.py
@@ -76,11 +76,11 @@ def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState and checkEventsInMokka:
+            if zeniState:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
-
-                cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
-                os.system(cmd)
+                if checkEventsInMokka:
+                    cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
+                    os.system(cmd)
 
 
     # --------------------------GLOBAL SETTINGS ------------------------------------

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM1_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM1_workflow.py
@@ -76,10 +76,11 @@ def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState and checkEventsInMokka:
+            if zeniState:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
-                cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
-                os.system(cmd)
+                if checkEventsInMokka:
+                    cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
+                    os.system(cmd)
 
 
     # --------------------------GLOBAL SETTINGS ------------------------------------

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM1_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM1_workflow.py
@@ -39,7 +39,7 @@ def command():
 
 
 
-def main(sessionFilename,createPDFReport=True):
+def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
     logging.info("------------------------------------------------")
     logging.info("------------QTM - pyCGM2 Workflow---------------")
     logging.info("------------------------------------------------")
@@ -76,7 +76,7 @@ def main(sessionFilename,createPDFReport=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState:
+            if zeniState and checkEventsInMokka:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
                 cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
                 os.system(cmd)

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM21_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM21_workflow.py
@@ -76,11 +76,11 @@ def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState and checkEventsInMokka:
+            if zeniState:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
-
-                cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
-                os.system(cmd)
+                if checkEventsInMokka:
+                    cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
+                    os.system(cmd)
 
     # --------------------------GLOBAL SETTINGS ------------------------------------
     # global setting ( in user/AppData)

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM21_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM21_workflow.py
@@ -38,7 +38,7 @@ def command():
     main(sessionFilename)
 
 
-def main(sessionFilename,createPDFReport=True):
+def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
     logging.info("------------------------------------------------")
     logging.info("------------QTM - pyCGM2 Workflow---------------")
     logging.info("------------------------------------------------")
@@ -76,7 +76,7 @@ def main(sessionFilename,createPDFReport=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState:
+            if zeniState and checkEventsInMokka:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
 
                 cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM22_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM22_workflow.py
@@ -77,11 +77,11 @@ def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState and checkEventsInMokka:
+            if zeniState:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
-
-                cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
-                os.system(cmd)
+                if checkEventsInMokka:
+                    cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
+                    os.system(cmd)
 
     # --------------------------GLOBAL SETTINGS ------------------------------------
     # global setting ( in user/AppData)

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM22_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM22_workflow.py
@@ -39,7 +39,7 @@ def command():
     sessionFilename = args.sessionFile
     main(sessionFilename)
 
-def main(sessionFilename,createPDFReport=True):
+def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
     logging.info("------------------------------------------------")
     logging.info("------------QTM - pyCGM2 Workflow---------------")
     logging.info("------------------------------------------------")
@@ -77,7 +77,7 @@ def main(sessionFilename,createPDFReport=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState:
+            if zeniState and checkEventsInMokka:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
 
                 cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM23_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM23_workflow.py
@@ -40,7 +40,7 @@ def command():
     main(sessionFilename)
 
 
-def main(sessionFilename,createPDFReport=True):
+def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
     logging.info("------------------------------------------------")
     logging.info("------------QTM - pyCGM2 Workflow---------------")
     logging.info("------------------------------------------------")
@@ -78,7 +78,7 @@ def main(sessionFilename,createPDFReport=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState:
+            if zeniState and checkEventsInMokka:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
 
                 cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM23_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM23_workflow.py
@@ -78,11 +78,11 @@ def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState and checkEventsInMokka:
+            if zeniState:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
-
-                cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
-                os.system(cmd)
+                if checkEventsInMokka:
+                    cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
+                    os.system(cmd)
 
 
     # --------------------------GLOBAL SETTINGS ------------------------------------

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM24_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM24_workflow.py
@@ -77,11 +77,11 @@ def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState and checkEventsInMokka:
+            if zeniState:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
-
-                cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
-                os.system(cmd)
+                if checkEventsInMokka:
+                    cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))
+                    os.system(cmd)
 
     # --------------------------GLOBAL SETTINGS ------------------------------------
     # global setting ( in user/AppData)

--- a/pyCGM2/Apps/QtmApps/CGMi/CGM24_workflow.py
+++ b/pyCGM2/Apps/QtmApps/CGMi/CGM24_workflow.py
@@ -39,7 +39,7 @@ def command():
     main(sessionFilename)
 
 
-def main(sessionFilename,createPDFReport=True):
+def main(sessionFilename,createPDFReport=True,checkEventsInMokka=True):
     logging.info("------------------------------------------------")
     logging.info("------------QTM - pyCGM2 Workflow---------------")
     logging.info("------------------------------------------------")
@@ -77,7 +77,7 @@ def main(sessionFilename,createPDFReport=True):
                                 fc_lowPass_marker=fc_marker,
                                 order_lowPass_marker=order_marker)
 
-            if zeniState:
+            if zeniState and checkEventsInMokka:
                 btkTools.smartWriter(acq, str(DATA_PATH + reconstructFilenameLabelled))
 
                 cmd = "Mokka.exe \"%s\""%(str(DATA_PATH + reconstructFilenameLabelled))


### PR DESCRIPTION
This small change allows selecting if Mokka opens or not. By default it checkEventsInMokka is set to True, which does not change default behaviour

However, with this we set the argument to False when running tests that use these workflows automatically without having Mokka opening up.