### PR TITLE
fix crashes in MarkerFiltering when there are zeroes in the signal

### DIFF
--- a/pyCGM2/Signal/signal_processing.py
+++ b/pyCGM2/Signal/signal_processing.py
@@ -83,7 +83,7 @@ def markerFiltering(btkAcq,markers,order=2, fc=6,zerosFiltering=True):
 
 
         N = len(array)
-        indexes = range(0,N)
+        indexes = list(range(0,N))
 
         for i in range(0,N):
             if array[i] == 0:

--- a/pyCGM2/Signal/signal_processing.py
+++ b/pyCGM2/Signal/signal_processing.py
@@ -101,8 +101,8 @@ def markerFiltering(btkAcq,markers,order=2, fc=6,zerosFiltering=True):
                 padlen = len(data) - 1
             filtValues_section.append(signal.filtfilt(b, a, data ,padlen=padlen,axis=0))
 
-        indexes = np.concatenate(splitIndexes)
-        values = np.concatenate(filtValues_section)
+        indexes = np.concatenate(splitIndexes) if splitIndexes != [] else []
+        values = np.concatenate(filtValues_section) if filtValues_section != [] else []
 
         out = np.zeros((N))
         j = 0


### PR DESCRIPTION
There was a bug in this function, which caused line 90 to crash the program when there were zeros in the array.

Converting the range to list fixes the issue.
```
INFO:pyCGM2:--------------------------MODEL FITTING ----------------------------------
2021-05-11 11:55:28,088 - [INFO] - pyCGM2 - (CGM23_workflow.py).main(153) - ----Processing of [Gait - CGM2 1.c3d]-----
INFO:pyCGM2:----Processing of [Gait - CGM2 1.c3d]-----
2021-05-11 11:55:28,106 - [INFO] - pyCGM2 - (CGM23_workflow.py).main(197) - [pyCGM2] --- Fitting operation ---
INFO:pyCGM2:[pyCGM2] --- Fitting operation ---
2021-05-11 11:55:28,170 - [INFO] - pyCGM2 - (cgm2_3.py).fitting(379) - [pyCGM2]  Computation from frame [7] to frame [421]
INFO:pyCGM2:[pyCGM2]  Computation from frame [7] to frame [421]
Traceback (most recent call last):
  File "F:\\Repositories\\qualisys_CGM2_workflow\\Templates\\Scripts\\src\\CGM2\\CGM_workflow.py", line 48, in <module>
    CGM23_workflow.main(session_xml_filename,createPDFReport=createPDFReport,checkEventsInMokka=checkEventsInMokka,anomalyException=anomalyException)
  File "F:\Miniconda3\envs\cgm2py37\lib\site-packages\pyCGM2\Apps\QtmApps\CGMi\CGM23_workflow.py", line 210, in main
    frameInit= vff, frameEnd= vlf )
  File "F:\Miniconda3\envs\cgm2py37\lib\site-packages\pyCGM2\Lib\CGM\cgm2_3.py", line 419, in fitting
    signal_processing.markerFiltering(acqGait,trackingMarkers,order=order, fc =fc)
  File "F:\Miniconda3\envs\cgm2py37\lib\site-packages\pyCGM2\Signal\signal_processing.py", line 122, in markerFiltering
    x = filterZeros(pointIt.GetValues()[:,0],bPoint,aPoint)
  File "F:\Miniconda3\envs\cgm2py37\lib\site-packages\pyCGM2\Signal\signal_processing.py", line 90, in filterZeros
    indexes[i] = -1
TypeError: 'range' object does not support item assignment
```